### PR TITLE
Add Windows Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ script:
   # Install ruby gem
   - gem install symengine-0.1.0.gem --user --verbose -- -DSymEngine_DIR=$our_install_dir
   # Test ruby gem
+  - gem install gem-path
   - cd `gem path symengine`
   - bundle exec rspec
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
  - 1.9.3
  - 2.0
  - 2.1
+ - 2.2
 
 install:
   - export RUBY_SOURCE_DIR=`pwd`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 project(ruby_wrapper)
 
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+
 set(CMAKE_PREFIX_PATH ${SymEngine_DIR} ${CMAKE_PREFIX_PATH})
 find_package(SymEngine 0.1.0 REQUIRED CONFIG
              PATH_SUFFIXES lib/cmake/symengine CMake/)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   - bundler env
   - bundle install
 
-  - if [%PLATFORM%] == [x64] appveyor DownloadFile "https://raw.githubusercontent.com/symengine/dependencies/5cff7d1736877336cf9fb58267111beea4fa152f/gmp-6.0.0-x86_64-w64-mingw32.7z" -FileName gmp.7z
+  - if [%PLATFORM%] == [x64] appveyor DownloadFile "https://raw.githubusercontent.com/isuruf/symengine-dependencies/binaries2/gmp-6.0.0-x86_64-w64-mingw32.7z" -FileName gmp.7z
   - if [%PLATFORM%] == [Win32] appveyor DownloadFile " https://raw.githubusercontent.com/symengine/dependencies/e1e9dc3e7288ba06c96b452fb556b11ef6d5299f/gmp-6.0.0-i686-w64-mingw32.7z" -FileName gmp.7z
   - 7z x -oC:\gmp gmp.7z > NUL
   - set PATH=C:\gmp\bin\;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,7 @@ install:
 
   - appveyor DownloadFile "https://raw.githubusercontent.com/symengine/dependencies/5cff7d1736877336cf9fb58267111beea4fa152f/gmp-6.0.0-x86_64-w64-mingw32.7z" -FileName gmp.7z
   - 7z x -oC:\gmp gmp.7z > NUL
+  - set PATH=C:\gmp\bin\;%PATH%
 
   - git clone https://github.com/symengine/symengine symengine-cpp
   - cd symengine-cpp
@@ -48,9 +49,12 @@ build_script:
   - gem install symengine-0.1.0.gem --verbose
   
 test_script:
+  - gem install gem-path
+  - gem path symengine > temp.txt
+  - set /p RUBY_GEM_DIR=<temp.txt
   # Test ruby gem
-  # cd `gem path symengine`
-  # bundle exec rspec
+  - cd %RUBY_GEM_DIR%
+  - bundle exec rspec
   
 
 # Enable this to be able to login to the build worker. You can use the

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,60 @@
+version: '{build}'
+
+environment:
+
+  matrix:
+    - RUBY_VERSION: "200-x64"
+      DEVKIT: C:\Ruby21-x64\DevKit
+      PLATFORM: "x64"
+    - RUBY_VERSION: "200"
+      DEVKIT: C:\Ruby21\DevKit
+      PLATFORM: "Win32"
+    - RUBY_VERSION: "21"
+      DEVKIT: C:\Ruby21\DevKit
+      PLATFORM: "Win32"
+    - RUBY_VERSION: "21-x64"
+      DEVKIT: C:\Ruby21-x64\DevKit
+      PLATFORM: "x64"
+    - RUBY_VERSION: "22"
+      DEVKIT: C:\Ruby21\DevKit
+      PLATFORM: "Win32"
+    - RUBY_VERSION: "22-x64"
+      DEVKIT: C:\Ruby21-x64\DevKit
+      PLATFORM: "x64"
+
+install:
+
+  - SET PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - "%DEVKIT%\\devkitvars.bat"
+  - gem install bundler --no-rdoc --no-ri
+  - bundler env
+  - bundle install
+
+  - appveyor DownloadFile "https://raw.githubusercontent.com/symengine/dependencies/5cff7d1736877336cf9fb58267111beea4fa152f/gmp-6.0.0-x86_64-w64-mingw32.7z" -FileName gmp.7z
+  - 7z x -oC:\gmp gmp.7z > NUL
+
+  - git clone https://github.com/symengine/symengine symengine-cpp
+  - cd symengine-cpp
+  - git checkout 8537c67507fae9b1d8d575d322c6ade4f1a59297
+  - cmake -G "MSYS Makefiles" -DGMP_DIR=C:\gmp -DBUILD_TESTS=no -DBUILD_BENCHMARKS=no .
+  - make
+  - make install
+  - cd ..
+
+build_script:
+  # Build ruby gem
+  - gem build symengine.gemspec
+  # Install ruby gem
+  - gem install symengine-0.1.0.gem --verbose
+  
+test_script:
+  # Test ruby gem
+  # cd `gem path symengine`
+  # bundle exec rspec
+  
+
+# Enable this to be able to login to the build worker. You can use the
+# `remmina` program in Ubuntu, use the login information that the line below
+# prints into the log.
+on_finish:
+- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,28 +3,24 @@ version: '{build}'
 environment:
 
   matrix:
-    - RUBY_VERSION: "22-x64"
-      DEVKIT: C:\Ruby21-x64\DevKit
-      PLATFORM: "x64"
     - RUBY_VERSION: "21-x64"
-      DEVKIT: C:\Ruby21-x64\DevKit
       PLATFORM: "x64"
-    - RUBY_VERSION: "200-x64"
-      DEVKIT: C:\Ruby21-x64\DevKit
+    - RUBY_VERSION: "21"
+      PLATFORM: "Win32"
+    - RUBY_VERSION: "22-x64"
       PLATFORM: "x64"
     - RUBY_VERSION: "22"
-      DEVKIT: C:\Ruby21\DevKit
       PLATFORM: "Win32"
-    - RUBY_VERSION: "21"
-      DEVKIT: C:\Ruby21\DevKit
-      PLATFORM: "Win32"
+    - RUBY_VERSION: "200-x64"
+      PLATFORM: "x64"
     - RUBY_VERSION: "200"
-      DEVKIT: C:\Ruby21\DevKit
       PLATFORM: "Win32"
 
 install:
 
   - SET PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - if [%PLATFORM%] == [x64] set DEVKIT=C:\Ruby21-x64\DevKit
+  - if [%PLATFORM%] == [Win32] set DEVKIT=C:\Ruby21\DevKit
   - "%DEVKIT%\\devkitvars.bat"
   - gem install bundler --no-rdoc --no-ri
   - bundler env

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,24 +3,24 @@ version: '{build}'
 environment:
 
   matrix:
-    - RUBY_VERSION: "200-x64"
+    - RUBY_VERSION: "22-x64"
       DEVKIT: C:\Ruby21-x64\DevKit
       PLATFORM: "x64"
-    - RUBY_VERSION: "200"
-      DEVKIT: C:\Ruby21\DevKit
-      PLATFORM: "Win32"
-    - RUBY_VERSION: "21"
-      DEVKIT: C:\Ruby21\DevKit
-      PLATFORM: "Win32"
     - RUBY_VERSION: "21-x64"
+      DEVKIT: C:\Ruby21-x64\DevKit
+      PLATFORM: "x64"
+    - RUBY_VERSION: "200-x64"
       DEVKIT: C:\Ruby21-x64\DevKit
       PLATFORM: "x64"
     - RUBY_VERSION: "22"
       DEVKIT: C:\Ruby21\DevKit
       PLATFORM: "Win32"
-    - RUBY_VERSION: "22-x64"
-      DEVKIT: C:\Ruby21-x64\DevKit
-      PLATFORM: "x64"
+    - RUBY_VERSION: "21"
+      DEVKIT: C:\Ruby21\DevKit
+      PLATFORM: "Win32"
+    - RUBY_VERSION: "200"
+      DEVKIT: C:\Ruby21\DevKit
+      PLATFORM: "Win32"
 
 install:
 
@@ -30,7 +30,8 @@ install:
   - bundler env
   - bundle install
 
-  - appveyor DownloadFile "https://raw.githubusercontent.com/symengine/dependencies/5cff7d1736877336cf9fb58267111beea4fa152f/gmp-6.0.0-x86_64-w64-mingw32.7z" -FileName gmp.7z
+  - if [%PLATFORM%] == [x64] appveyor DownloadFile "https://raw.githubusercontent.com/symengine/dependencies/5cff7d1736877336cf9fb58267111beea4fa152f/gmp-6.0.0-x86_64-w64-mingw32.7z" -FileName gmp.7z
+  - if [%PLATFORM%] == [Win32] appveyor DownloadFile " https://raw.githubusercontent.com/symengine/dependencies/e1e9dc3e7288ba06c96b452fb556b11ef6d5299f/gmp-6.0.0-i686-w64-mingw32.7z" -FileName gmp.7z
   - 7z x -oC:\gmp gmp.7z > NUL
   - set PATH=C:\gmp\bin\;%PATH%
 
@@ -60,5 +61,5 @@ test_script:
 # Enable this to be able to login to the build worker. You can use the
 # `remmina` program in Ubuntu, use the login information that the line below
 # prints into the log.
-on_finish:
-- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+#on_finish:
+#- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/ext/symengine/CMakeLists.txt
+++ b/ext/symengine/CMakeLists.txt
@@ -10,7 +10,7 @@ set(RUBY_WRAPPER_SRC
 include_directories(BEFORE ${RUBY_INCLUDE_DIRS})
 
 add_library(symengine_ruby SHARED ${RUBY_WRAPPER_SRC})
-target_link_libraries(symengine_ruby ${SYMENGINE_LIBRARIES} ${RUBY_LIBRARIES})
+target_link_libraries(symengine_ruby ${SYMENGINE_LIBRARIES} ${RUBY_LIBRARY})
 set_target_properties(symengine_ruby PROPERTIES
                         PREFIX ""
                         OUTPUT_NAME "symengine"

--- a/ext/symengine/CMakeLists.txt
+++ b/ext/symengine/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(symengine_ruby SHARED ${RUBY_WRAPPER_SRC})
 target_link_libraries(symengine_ruby ${SYMENGINE_LIBRARIES} ${RUBY_LIBRARY})
 set_target_properties(symengine_ruby PROPERTIES
                         PREFIX ""
+                        SUFFIX ".so"
                         OUTPUT_NAME "symengine"
                         LIBRARY_OUTPUT_DIRECTORY "${ruby_wrapper_BINARY_DIR}/lib/symengine"
                      )

--- a/ext/symengine/cmake_install.cmake
+++ b/ext/symengine/cmake_install.cmake
@@ -1,0 +1,43 @@
+# Install script for directory: C:/Users/dell/projects/symengine.rb/ext/symengine
+
+# Set the install prefix
+if(NOT DEFINED CMAKE_INSTALL_PREFIX)
+  set(CMAKE_INSTALL_PREFIX "C:/Users/dell/projects/symengine.rb")
+endif()
+string(REGEX REPLACE "/$" "" CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
+
+# Set the install configuration name.
+if(NOT DEFINED CMAKE_INSTALL_CONFIG_NAME)
+  if(BUILD_TYPE)
+    string(REGEX REPLACE "^[^A-Za-z0-9_]+" ""
+           CMAKE_INSTALL_CONFIG_NAME "${BUILD_TYPE}")
+  else()
+    set(CMAKE_INSTALL_CONFIG_NAME "Release")
+  endif()
+  message(STATUS "Install configuration: \"${CMAKE_INSTALL_CONFIG_NAME}\"")
+endif()
+
+# Set the component getting installed.
+if(NOT CMAKE_INSTALL_COMPONENT)
+  if(COMPONENT)
+    message(STATUS "Install component: \"${COMPONENT}\"")
+    set(CMAKE_INSTALL_COMPONENT "${COMPONENT}")
+  else()
+    set(CMAKE_INSTALL_COMPONENT)
+  endif()
+endif()
+
+if(NOT CMAKE_INSTALL_COMPONENT OR "${CMAKE_INSTALL_COMPONENT}" STREQUAL "Unspecified")
+  file(INSTALL DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/symengine" TYPE STATIC_LIBRARY OPTIONAL FILES "C:/Users/dell/projects/symengine.rb/ext/symengine/libsymengine.dll.a")
+endif()
+
+if(NOT CMAKE_INSTALL_COMPONENT OR "${CMAKE_INSTALL_COMPONENT}" STREQUAL "Unspecified")
+  file(INSTALL DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/symengine" TYPE SHARED_LIBRARY FILES "C:/Users/dell/projects/symengine.rb/ext/symengine/symengine.so")
+  if(EXISTS "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/lib/symengine/symengine.so" AND
+     NOT IS_SYMLINK "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/lib/symengine/symengine.so")
+    if(CMAKE_INSTALL_DO_STRIP)
+      execute_process(COMMAND "C:/Users/dell/Downloads/DevKit/mingw/bin/strip.exe" "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/lib/symengine/symengine.so")
+    endif()
+  endif()
+endif()
+

--- a/ext/symengine/extconf.rb
+++ b/ext/symengine/extconf.rb
@@ -1,1 +1,5 @@
-exec 'cmake -DCMAKE_INSTALL_PREFIX=../../ %s ../../ ' % [ARGV.join(" ")]
+require 'rbconfig'
+
+ruby_executable = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['RUBY_INSTALL_NAME'] + RbConfig::CONFIG['EXEEXT'])
+exec 'cmake -DCMAKE_INSTALL_PREFIX=../../ -DRUBY_EXECUTABLE=%s %s ../../ ' % [ruby_executable, ARGV.join(" ")]
+

--- a/ext/symengine/extconf.rb
+++ b/ext/symengine/extconf.rb
@@ -1,5 +1,15 @@
 require 'rbconfig'
 
 ruby_executable = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['RUBY_INSTALL_NAME'] + RbConfig::CONFIG['EXEEXT'])
-exec 'cmake -DCMAKE_INSTALL_PREFIX=../../ -DRUBY_EXECUTABLE=%s %s ../../ ' % [ruby_executable, ARGV.join(" ")]
 
+generator = ""
+
+if (RbConfig::CONFIG['host_os'] =~ /mingw/)
+    generator = '-G "MSYS Makefiles"'
+elsif (RbConfig::CONFIG['host_os'] =~ /cygwin/)
+    generator = '-G "Unix Makefiles"'
+elsif (RbConfig::CONFIG['host_os'] =~ /mswin/)
+    generator = '-G "NMake Makefiles"'
+end
+
+exec 'cmake %s -DCMAKE_INSTALL_PREFIX=../../ -DRUBY_EXECUTABLE=%s %s ../../ ' % [generator, ruby_executable, ARGV.join(" ")]

--- a/symengine.gemspec
+++ b/symengine.gemspec
@@ -16,5 +16,4 @@ Gem::Specification.new do |gem|
     gem.add_development_dependency 'rspec', '~> 3.0'
     gem.add_development_dependency 'test-unit', '~> 3.1'
     gem.add_development_dependency 'rdoc', '~> 4.0'
-    gem.add_development_dependency 'path', '~> 1.3'
 end

--- a/symengine.gemspec
+++ b/symengine.gemspec
@@ -6,7 +6,8 @@ Gem::Specification.new do |gem|
     gem.authors = ['Abinash Meher']
     gem.email = ["abinashdakshana999@gmail.com"]
     gem.homepage = 'https://github.com/sympy/symengine'
-    gem.files = Dir["lib/**/*", "bin/*", "LICENSE", "*.md", "ext/**/*", "spec/**/*", "CMakeLists.txt", "Gemfile", "symengine.gemspec"]
+    gem.files = Dir["lib/**/*", "bin/*", "LICENSE", "*.md", "ext/**/*", "spec/**/*", "CMakeLists.txt", "Gemfile",
+                    "cmake/FindRuby.cmake", "symengine.gemspec"]
     gem.require_paths = ["lib"]
     gem.extensions = ["ext/symengine/extconf.rb"]
     gem.license = 'MIT'
@@ -15,5 +16,5 @@ Gem::Specification.new do |gem|
     gem.add_development_dependency 'rspec', '~> 3.0'
     gem.add_development_dependency 'test-unit', '~> 3.1'
     gem.add_development_dependency 'rdoc', '~> 4.0'
-    gem.add_development_dependency 'path', '~> 1.3.3'
+    gem.add_development_dependency 'path', '~> 1.3'
 end


### PR DESCRIPTION
I'm using cmake to generate the Makefile in `extconf.rb` and let `DevKit` handle the rest.

Building the C extension goes fine, but using it causes errors.

CMake produces `lib\symengine\symengine.dll` and `lib\symengine\symengine.dll.a`. 
It is imported by `lib\symengine.rb` as `require 'symengine/symengine'
I get this error. 

```
C:/Users/dell/projects/symengine.rb/lib/symengine.rb:1:in `require': cannot load
 such file -- symengine/symengine (LoadError)
        from C:/Users/dell/projects/symengine.rb/lib/symengine.rb:1:in `<top (re
quired)>'
        from C:/Users/dell/projects/symengine.rb/spec/spec_helper.rb:16:in `requ
ire_relative'
        from C:/Users/dell/projects/symengine.rb/spec/spec_helper.rb:16:in `<top
 (required)>'
```

If I change the extension name from `.dll` to `.so` I get a different error.
```
C:/Users/dell/projects/symengine.rb/lib/symengine.rb:1:in `require': 126: The sp
ecified module could not be found.   - C:/Users/dell/projects/symengine.rb/lib/s
ymengine/symengine.so (LoadError)
        from C:/Users/dell/projects/symengine.rb/lib/symengine.rb:1:in `<top (re
quired)>'
        from C:/Users/dell/projects/symengine.rb/spec/spec_helper.rb:16:in `requ
ire_relative'
        from C:/Users/dell/projects/symengine.rb/spec/spec_helper.rb:16:in `<top
 (required)>'
```

@mohawkjohn @agarie @abinashmeher999
 