### PR TITLE
Add classes for Add, Mul and Pow

### DIFF
--- a/ext/symengine/symengine.c
+++ b/ext/symengine/symengine.c
@@ -55,4 +55,14 @@ void Init_symengine() {
     rb_define_const(m_symengine, "PI", cconstant_pi());
     rb_define_const(m_symengine, "E", cconstant_e());
     rb_define_const(m_symengine, "EULER_GAMMA", cconstant_euler_gamma());
+
+    //Add class
+    c_add = rb_define_class_under(m_symengine, "Add", c_basic);
+
+    //Mul class
+    c_mul = rb_define_class_under(m_symengine, "Mul", c_basic);
+
+    //Pow class
+    c_pow = rb_define_class_under(m_symengine, "Pow", c_basic);
+
 }

--- a/ext/symengine/symengine.h
+++ b/ext/symengine/symengine.h
@@ -12,5 +12,8 @@ VALUE c_symbol;
 VALUE c_integer;
 VALUE c_rational;
 VALUE c_constant;
+VALUE c_add;
+VALUE c_mul;
+VALUE c_pow;
 
 #endif //SYMENGINE_H_

--- a/ext/symengine/symengine_macros.c
+++ b/ext/symengine/symengine_macros.c
@@ -45,6 +45,12 @@ VALUE Klass_of_Basic(const basic_struct *basic_ptr) {
             return c_rational;
         case SYMENGINE_CONSTANT:
             return c_constant;
+        case SYMENGINE_ADD:
+            return c_add;
+        case SYMENGINE_MUL:
+            return c_mul;
+        case SYMENGINE_POW:
+            return c_pow;
         default:
             return c_basic;
     }

--- a/spec/arit_spec.rb
+++ b/spec/arit_spec.rb
@@ -55,21 +55,31 @@ describe 'Arithmetic test cases' do
     assert e == (x + y)**2
     assert e != x**2 + 2 * x * y + y**2
     expect(e).to be_a SymEngine::Basic
+    expect(e).to be_an_instance_of SymEngine::Pow
     assert f == x**2 + 2 * x * y + y**2
     expect(f).to be_a SymEngine::Basic
+    expect(f).to be_an_instance_of SymEngine::Add
   end
 
   it 'test_arit6' do
     x = SymEngine::Symbol.new('x')
     y = SymEngine::Symbol.new('y')
+
     e = x + y
     assert(e.to_s == 'x + y') || 'y + x'
+    expect(e).to be_an_instance_of SymEngine::Add
+
     e = x * y
     assert(e.to_s == 'x*y') || 'y*x'
+    expect(e).to be_an_instance_of SymEngine::Mul
+
     e = Integer(2) * x
     assert e.to_s == '2*x'
+    expect(e).to be_an_instance_of SymEngine::Mul
+
     e = 2 * x
     assert e.to_s == '2*x'
+    expect(e).to be_an_instance_of SymEngine::Mul
   end
 
   it 'test_arit7' do

--- a/spec/arit_spec.rb
+++ b/spec/arit_spec.rb
@@ -54,9 +54,9 @@ describe 'Arithmetic test cases' do
     f = e.expand
     assert e == (x + y)**2
     assert e != x**2 + 2 * x * y + y**2
-    expect(e).to be_an_instance_of SymEngine::Basic
+    expect(e).to be_a SymEngine::Basic
     assert f == x**2 + 2 * x * y + y**2
-    expect(f).to be_an_instance_of SymEngine::Basic
+    expect(f).to be_a SymEngine::Basic
   end
 
   it 'test_arit6' do

--- a/spec/basic_spec.rb
+++ b/spec/basic_spec.rb
@@ -142,7 +142,7 @@ describe SymEngine do
           z = SymEngine::Symbol.new('z')
           e = (x**y + z)
           f = e.args
-          expect(f).to be_an Array
+          expect(f).to be_an_instance_of Array
           expect(f.length).to be 2
           expect(f.to_set).to eql([x**y, z].to_set)
         end
@@ -157,7 +157,7 @@ describe SymEngine do
           z = SymEngine::Symbol.new('z')
           e = (x**y / z)
           f = e.free_symbols
-          expect(f).to be_a Set
+          expect(f).to be_an_instance_of Set
           expect(f.length).to be 3
           expect(f).to eql([x, y, z].to_set)
         end

--- a/spec/basic_spec.rb
+++ b/spec/basic_spec.rb
@@ -27,7 +27,7 @@ describe SymEngine do
           it 'returns a initialised Basic object that is result of
                         self added to the argument' do
             c = @a + @b
-            expect(c).to be_an_instance_of SymEngine::Basic
+            expect(c).to be_a SymEngine::Basic
             expect(c.to_s).to eql('x + y')
           end
         end
@@ -37,7 +37,7 @@ describe SymEngine do
           it 'returns a initialised Basic object that is result of
                         argument subtracted from self' do
             c = @a - @b
-            expect(c).to be_an_instance_of SymEngine::Basic
+            expect(c).to be_a SymEngine::Basic
             expect(c.to_s).to eql('x - y')
           end
         end
@@ -47,7 +47,7 @@ describe SymEngine do
           it 'returns a initialised Basic object that is result of
                         self multiplied by the argument' do
             c = @a * @b
-            expect(c).to be_an_instance_of SymEngine::Basic
+            expect(c).to be_a SymEngine::Basic
             expect(c.to_s).to eql('x*y')
           end
         end
@@ -57,7 +57,7 @@ describe SymEngine do
           it 'returns a initialised Basic object that is result of
                         self divided by the argument' do
             c = @a / @b
-            expect(c).to be_an_instance_of SymEngine::Basic
+            expect(c).to be_a SymEngine::Basic
             expect(c.to_s).to eql('x/y')
           end
         end
@@ -67,7 +67,7 @@ describe SymEngine do
           it 'returns a initialised Basic object that is result of
                         self raised to the power of argument' do
             c = @a**@b
-            expect(c).to be_an_instance_of SymEngine::Basic
+            expect(c).to be_a SymEngine::Basic
             expect(c.to_s).to eql('x**y')
           end
         end
@@ -78,7 +78,7 @@ describe SymEngine do
               and returns the result' do
             a = @a**3
             c = a.diff(@a)
-            expect(c).to be_an_instance_of SymEngine::Basic
+            expect(c).to be_a SymEngine::Basic
             expect(c).to eq(3 * @a**2)
             expect(a.diff(2)).to be_nil
           end
@@ -127,7 +127,7 @@ describe SymEngine do
         context "doesn't take any argument" do
           it 'returns the negation of self' do
             p = -@x
-            expect(p).to be_an_instance_of SymEngine::Basic
+            expect(p).to be_a SymEngine::Basic
             expect(p.to_s).to eql('-a')
           end
         end
@@ -142,7 +142,7 @@ describe SymEngine do
           z = SymEngine::Symbol.new('z')
           e = (x**y + z)
           f = e.args
-          expect(f).to be_an_instance_of Array
+          expect(f).to be_an Array
           expect(f.length).to be 2
           expect(f.to_set).to eql([x**y, z].to_set)
         end
@@ -157,7 +157,7 @@ describe SymEngine do
           z = SymEngine::Symbol.new('z')
           e = (x**y / z)
           f = e.free_symbols
-          expect(f).to be_an_instance_of Set
+          expect(f).to be_a Set
           expect(f.length).to be 3
           expect(f).to eql([x, y, z].to_set)
         end
@@ -173,7 +173,7 @@ describe SymEngine do
           e = (x + y + z) * (x + y + z)
           f = e.expand
           expect(e.to_s).to eql('(x + y + z)**2')
-          expect(f).to be_an_instance_of SymEngine::Basic
+          expect(f).to be_a SymEngine::Basic
           expect(f.to_s).to eql('2*x*y + 2*x*z + 2*y*z + x**2 + y**2 + z**2')
           expect(e == f).to be false
         end

--- a/spec/constant_spec.rb
+++ b/spec/constant_spec.rb
@@ -18,15 +18,15 @@ describe SymEngine do
       context 'with summation with one' do
         it 'returns an initialised Basic object that is equalent to 1 + pi' do
           f = @a + @d
-          expect(@a).to be_an_instance_of SymEngine::Constant
-          expect(f).to be_an_instance_of SymEngine::Basic
+          expect(@a).to be_a SymEngine::Constant
+          expect(f).to be_a SymEngine::Basic
           expect(f.to_s).to eql('1 + pi')
         end
       end
 
       context 'with plus one and minus one' do
         it 'returns a Constant' do
-          expect(1 + @a - 1).to be_an_instance_of SymEngine::Constant
+          expect(1 + @a - 1).to be_a SymEngine::Constant
         end
       end
 
@@ -36,15 +36,15 @@ describe SymEngine do
       context 'with powered to zero' do
         it 'returns an initialised Basic object that is equalent 1' do
           f = @c ** @e
-          expect(@c).to be_an_instance_of SymEngine::Constant
-          expect(f).to be_an_instance_of SymEngine::Integer
+          expect(@c).to be_a SymEngine::Constant
+          expect(f).to be_a SymEngine::Integer
           expect(f.to_s).to eql('1')
         end
       end
 
       context 'with plus one and minus one' do
         it 'returns a Constant' do
-          expect(1 + @c - 1).to be_an_instance_of SymEngine::Constant
+          expect(1 + @c - 1).to be_a SymEngine::Constant
         end
       end
 
@@ -54,15 +54,15 @@ describe SymEngine do
       context 'with summation with x' do
         it 'returns an initialised Basic object that is equalent to x + E' do
           f = @b + @x
-          expect(@b).to be_an_instance_of SymEngine::Constant
-          expect(f).to be_an_instance_of SymEngine::Basic
+          expect(@b).to be_a SymEngine::Constant
+          expect(f).to be_a SymEngine::Basic
           expect(f.to_s).to eql('x + E')
         end
       end
 
       context 'with plus one and minus one' do
         it 'returns a Constant' do
-          expect(1 + @b - 1).to be_an_instance_of SymEngine::Constant
+          expect(1 + @b - 1).to be_a SymEngine::Constant
         end
       end
 

--- a/spec/constant_spec.rb
+++ b/spec/constant_spec.rb
@@ -18,7 +18,7 @@ describe SymEngine do
       context 'with summation with one' do
         it 'returns an initialised Basic object that is equalent to 1 + pi' do
           f = @a + @d
-          expect(@a).to be_a SymEngine::Constant
+          expect(@a).to be_an_instance_of SymEngine::Constant
           expect(f).to be_a SymEngine::Basic
           expect(f.to_s).to eql('1 + pi')
         end
@@ -26,7 +26,7 @@ describe SymEngine do
 
       context 'with plus one and minus one' do
         it 'returns a Constant' do
-          expect(1 + @a - 1).to be_a SymEngine::Constant
+          expect(1 + @a - 1).to be_an_instance_of SymEngine::Constant
         end
       end
 
@@ -36,15 +36,15 @@ describe SymEngine do
       context 'with powered to zero' do
         it 'returns an initialised Basic object that is equalent 1' do
           f = @c ** @e
-          expect(@c).to be_a SymEngine::Constant
-          expect(f).to be_a SymEngine::Integer
+          expect(@c).to be_an_instance_of SymEngine::Constant
+          expect(f).to be_an_instance_of SymEngine::Integer
           expect(f.to_s).to eql('1')
         end
       end
 
       context 'with plus one and minus one' do
         it 'returns a Constant' do
-          expect(1 + @c - 1).to be_a SymEngine::Constant
+          expect(1 + @c - 1).to be_an_instance_of SymEngine::Constant
         end
       end
 
@@ -54,7 +54,7 @@ describe SymEngine do
       context 'with summation with x' do
         it 'returns an initialised Basic object that is equalent to x + E' do
           f = @b + @x
-          expect(@b).to be_a SymEngine::Constant
+          expect(@b).to be_an_instance_of SymEngine::Constant
           expect(f).to be_a SymEngine::Basic
           expect(f.to_s).to eql('x + E')
         end
@@ -62,7 +62,7 @@ describe SymEngine do
 
       context 'with plus one and minus one' do
         it 'returns a Constant' do
-          expect(1 + @b - 1).to be_a SymEngine::Constant
+          expect(1 + @b - 1).to be_an_instance_of SymEngine::Constant
         end
       end
 

--- a/spec/integer_spec.rb
+++ b/spec/integer_spec.rb
@@ -7,8 +7,8 @@ describe SymEngine do
         it 'gives a new SymEngine::Integer instance' do
           a = SymEngine::Integer.new(123)
           b = SymEngine::Integer.new(-123)
-          expect(a).to be_a SymEngine::Integer
-          expect(b).to be_a SymEngine::Integer
+          expect(a).to be_an_instance_of SymEngine::Integer
+          expect(b).to be_an_instance_of SymEngine::Integer
           expect(a.to_s).to eq('123')
           expect(b.to_s).to eq('-123')
           c = SymEngine::Integer.new(12_345_678_912_345_678_912)

--- a/spec/integer_spec.rb
+++ b/spec/integer_spec.rb
@@ -7,8 +7,8 @@ describe SymEngine do
         it 'gives a new SymEngine::Integer instance' do
           a = SymEngine::Integer.new(123)
           b = SymEngine::Integer.new(-123)
-          expect(a).to be_an_instance_of SymEngine::Integer
-          expect(b).to be_an_instance_of SymEngine::Integer
+          expect(a).to be_a SymEngine::Integer
+          expect(b).to be_a SymEngine::Integer
           expect(a.to_s).to eq('123')
           expect(b.to_s).to eq('-123')
           c = SymEngine::Integer.new(12_345_678_912_345_678_912)
@@ -27,13 +27,13 @@ describe SymEngine do
       context 'using a ruby integer as the second operand' do
         it 'succeeds with commutative operations' do
           b = @a * 2
-          expect(b).to be_an_instance_of SymEngine::Basic
+          expect(b).to be_a SymEngine::Basic
           expect(b).to eq(SymEngine::Integer.new(2) * @a)
         end
 
         it 'succeeds with non commutative operations' do
           b = @a / 2
-          expect(b).to be_an_instance_of SymEngine::Basic
+          expect(b).to be_a SymEngine::Basic
           expect(b).to eq(@a / SymEngine::Integer.new(2))
         end
       end
@@ -41,13 +41,13 @@ describe SymEngine do
       context 'using a ruby integer as the first operand' do
         it 'succeeds with commutative operations' do
           b = 2 * @a
-          expect(b).to be_an_instance_of SymEngine::Basic
+          expect(b).to be_a SymEngine::Basic
           expect(b).to eq(@a * SymEngine::Integer.new(2))
         end
 
         it 'succeeds with non commutative operations' do
           b = 2 / @a
-          expect(b).to be_an_instance_of SymEngine::Basic
+          expect(b).to be_a SymEngine::Basic
           expect(b).to eq(SymEngine::Integer.new(2) / @a)
         end
       end

--- a/spec/rational_spec.rb
+++ b/spec/rational_spec.rb
@@ -7,7 +7,7 @@ describe SymEngine do
         it 'returns an instance of SymEngine::Rational class' do
           a = Rational('2/3')
           a = SymEngine::Rational.new(a)
-          expect(a).to be_an_instance_of SymEngine::Rational
+          expect(a).to be_a SymEngine::Rational
           expect(a.to_s).to eq('2/3')
         end
       end
@@ -22,13 +22,13 @@ describe SymEngine do
       context 'using a ruby Rational as the second operand' do
         it 'succeeds with commutative operations' do
           c = @a * @b
-          expect(c).to be_an_instance_of SymEngine::Basic
+          expect(c).to be_a SymEngine::Basic
           expect(c).to eq(SymEngine::Rational.new(@b) * @a)
         end
 
         it 'succeeds with non commutative operations' do
           c = @a / @b
-          expect(c).to be_an_instance_of SymEngine::Basic
+          expect(c).to be_a SymEngine::Basic
           expect(c).to eq(@a / SymEngine::Rational.new(@b))
         end
       end
@@ -36,13 +36,13 @@ describe SymEngine do
       context 'using a ruby Rational as the first operand' do
         it 'succeeds with commutative operations' do
           c = @b * @a
-          expect(c).to be_an_instance_of SymEngine::Basic
+          expect(c).to be_a SymEngine::Basic
           expect(c).to eq(@a * SymEngine::Rational.new(@b))
         end
 
         it 'succeeds with non commutative operations' do
           c = @b / @a
-          expect(c).to be_an_instance_of SymEngine::Basic
+          expect(c).to be_a SymEngine::Basic
           expect(c).to eq(SymEngine::Rational.new(@b) / @a)
         end
       end


### PR DESCRIPTION
Changing the class of addition, multiplication and power expressions to `Add`, `Mul`, and `Pow` to reflect SymEngine classes.