### PR TITLE
Travis: fetch all symengine's pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ install:
 
   - git clone https://github.com/symengine/symengine symengine-cpp
   - cd symengine-cpp
+  - git config --add remote.origin.fetch '+refs/pull/*/head:refs/remotes/origin/pr/*'
+  - git fetch origin
   - git checkout `cat ../symengine_version.txt`
 
   # Setup travis for C++ library


### PR DESCRIPTION
That way the `symengine_version.txt` can reference a commit that is only
available in a symengine's pull request that is not merged yet. This allows to
test a proposed change and its Ruby wrappers.